### PR TITLE
[event-property] Allow for lazy event properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Reon.trigger(eventHandler, sourceComponent, [objectContainingData]);
 
 // Forward an event previously received from Reon / React
 Reon.forward(eventHandler, sourceComponent, originalEvent, [objectContainingData]);
+
+// Create eventData object with lazy properties
+Reon.lazy(properties, [objectToAttachTo]);
 ```
 
 The `eventHandler` will receive an object as its first argument which contains all of the properties of `objectContainingData` and optionally the properties `reonEvent`, `reactEvent` and `nativeEvent` when using `Reon.forward`.
@@ -83,6 +86,30 @@ const App = (props) => (
     <Button label="foo" onClick={e => {
         e.stopPropagation();
         console.log(e.value);
+    }} />
+);
+```
+
+### Creating lazy event properties
+
+```js
+import Reon from 'reon';
+
+const Button = (props) => (
+    <button onClick={() => {
+            Reon.trigger(props.onClick, this, Reon.lazy({
+                button: () => this,
+                test: () => 'value of test property'
+            }));
+        }}>
+        {props.label}
+    </button>
+);
+
+const App = (props) => (
+    <Button label="foo" onClick={e => {
+        console.log(e.button); // prints Button instance
+        console.log(e.test); // prints "value of test property"
     }} />
 );
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,24 @@ function executeEvent(handler, reactElement, properties) {
 export default
 class ReonEvent {
 
+    static lazy(properties, object = {}) {
+        const descriptors = {};
+        Object.keys(properties).forEach(key => {
+            const descriptor = { configurable: true, enumerable: true };
+
+            if (typeof properties[key] == 'function') {
+                descriptor.get = properties[key];
+            } else {
+                descriptor.writable = false;
+                descriptor.value = properties[key];
+            }
+
+            descriptors[key] = descriptor;
+        });
+
+        return Object.defineProperties(object, descriptors);
+    }
+
     static trigger(handler, reactElement, properties = {}) {
         if (__DEV__) {
             Object.keys(properties).forEach(key => {
@@ -105,7 +123,10 @@ class ReonEvent {
 
     constructor(reactElement, properties) {
         this[__PROPERTIES__] = Object.keys(properties);
-        Object.assign(this, properties);
+
+        if (typeof properties === 'object')
+            Object.defineProperties(this, Object.getOwnPropertyDescriptors(properties));
+
         this.target = reactElement;
     }
 
@@ -150,5 +171,6 @@ class ReonEvent {
 
 export const trigger = ReonEvent.trigger;
 export const forward = ReonEvent.forward;
+export const lazy = ReonEvent.lazy;
 
 PooledClass.addPoolingTo(ReonEvent, PooledClass.twoArgumentPooler);

--- a/tests/index.js
+++ b/tests/index.js
@@ -236,4 +236,36 @@ describe('Reon', () => {
 
     });
 
+    it('should preserve original property descriptors', () => {
+        const eventData = Object.defineProperty({}, 'propTest', {
+            configurable: true,
+            enumerable: true,
+            get: () => 'test success'
+        });
+
+        const handler = jest.fn(e => {
+            expect(e.propTest).toBe('test success');
+        });
+
+        Reon.trigger(handler, undefined, eventData);
+        expect(handler.mock.calls.length).toBe(1);
+    });
+
+    it('should set descriptors for accessors', () => {
+        const eventData = Reon.lazy({
+            propTest: () => 'test success',
+            propRegular: 'abc',
+            propTest2: 1234
+        });
+
+        const handler = jest.fn(e => {
+            expect(e.propTest).toBe('test success');
+            expect(e.propRegular).toBe('abc');
+            expect(e.propTest2).toBe(1234);
+        });
+
+        Reon.trigger(handler, undefined, eventData);
+        expect(handler.mock.calls.length).toBe(1);
+    })
+
 });


### PR DESCRIPTION
See https://github.com/ambassify/reon/pull/11

This allows for the usage of lazy properties.

`Reon.lazy({ ... })` will convert each function property to an accessor function, other properties are assigned as non-writable.