### PR TITLE
feat: deprecate "reactElement" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,8 @@ This library acts as a helper dealing with [React's event system](https://facebo
 
 ## Installation
 
-### React >= 17.0.0
-
 ```
 npm install --save reon
-```
-
-### React >= 15.4.0 AND < 17.0.0
-
-```
-npm install --save reon@^2
 ```
 
 ### React < 15.4.0

--- a/README.md
+++ b/README.md
@@ -37,19 +37,17 @@ if (this.props.onUploadReady)
 
 you now write
 ```js
-Reon.trigger(this.props.onUploadReady, this, {
-    file: file
-});
+Reon.trigger(this.props.onUploadReady, { file });
 ```
 
 ## Usage
 
 ```
 // Trigger new events
-Reon.trigger(eventHandler, sourceComponent, [objectContainingData]);
+Reon.trigger(eventHandler, [objectContainingData]);
 
 // Forward an event previously received from Reon / React
-Reon.forward(eventHandler, sourceComponent, originalEvent, [objectContainingData]);
+Reon.forward(eventHandler, originalEvent, [objectContainingData]);
 
 // Create eventData object with lazy properties
 Reon.lazy(properties, [objectToAttachTo]);
@@ -70,7 +68,7 @@ import Reon from 'reon';
 
 const Button = (props) => (
     <button onClick={e => {
-            Reon.trigger(props.onClick, this, { value: props.label });
+            Reon.trigger(props.onClick, { value: props.label });
         }}>
         {props.label}
     </button>
@@ -90,7 +88,7 @@ import Reon from 'reon';
 
 const Button = (props) => (
     <button onClick={e => {
-            Reon.forward(props.onClick, this, e, { value: props.label });
+            Reon.forward(props.onClick, e, { value: props.label });
         }}>
         {props.label}
     </button>
@@ -111,7 +109,7 @@ import Reon from 'reon';
 
 const Button = (props) => (
     <button onClick={() => {
-            Reon.trigger(props.onClick, this, Reon.lazy({
+            Reon.trigger(props.onClick, Reon.lazy({
                 button: () => this,
                 test: () => 'value of test property'
             }));

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/ambassify/reon/issues"
   },
   "homepage": "https://github.com/ambassify/reon#readme",
+  "peerDependencies": {
+    "react": ">=15"
+  },
   "devDependencies": {
     "@babel/cli": "^7.12.10",
     "@babel/core": "^7.12.10",

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,9 @@ class ReonEvent {
     preventDefault() {
         this[__DEFAULT_PREVENTED__] = true;
 
-        if (this.reactEvent)
+        if (this.reonEvent)
+            this.reonEvent.preventDefault();
+        else if (this.reactEvent)
             this.reactEvent.preventDefault();
         else if (this.nativeEvent)
             this.nativeEvent.preventDefault();
@@ -169,7 +171,9 @@ class ReonEvent {
     stopPropagation() {
         this[__PROPAGATION_STOPPED__] = true;
 
-        if (this.reactEvent)
+        if (this.reonEvent)
+            this.reonEvent.stopPropagation();
+        else if (this.reactEvent)
             this.reactEvent.stopPropagation();
         else if (this.nativeEvent)
             this.nativeEvent.stopPropagation();

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,19 +1,15 @@
-'use strict';
-
-import React from 'react';
+import React, { createElement } from 'react';
 import TestUtils from 'react-dom/test-utils';
 import Reon, { isSyntheticEvent } from '../src/index';
 import fireEvent from '@testing-library/user-event';
 
 describe('Reon', () => {
 
-    it('should trigger the handler with target and arguments', () => {
-        const fixt_target = Symbol('target');
+    it('should trigger the handler with arguments', () => {
         const fixt_properties = { foo: 'bar' };
 
         const handler = jest.fn(e => {
             expect(e instanceof Reon).toBe(true);
-            expect(e.target).toBe(fixt_target);
 
             expect(e.isDefaultPrevented()).toBeFalsy();
             expect(e.isPropagationStopped()).toBeFalsy();
@@ -23,9 +19,10 @@ describe('Reon', () => {
             }
         });
 
-        Reon.trigger(handler, fixt_target, fixt_properties);
+        Reon.trigger(handler, fixt_properties);
         expect(handler.mock.calls.length).toBe(1);
     });
+
 
     it('should ignore non-function handlers without errors', () => {
         const handler = undefined;
@@ -33,18 +30,13 @@ describe('Reon', () => {
     });
 
     it('should be able to forward Reon events', () => {
-        const fixt_target = Symbol('target');
-        const fixt_target2 = Symbol('target2');
         const fixt_properties = { foo: 'bar' };
         const fixt_properties2 = { baz: 'foo' };
-        const fixt_event = new Reon(fixt_target2, fixt_properties2);
+        const fixt_event = new Reon(fixt_properties2);
 
         const handler = jest.fn(e => {
             expect(e instanceof Reon).toBe(true);
             expect(e.reonEvent instanceof Reon).toBe(true);
-
-            expect(e.target).toBe(fixt_target);
-            expect(e.reonEvent.target).toBe(fixt_target2);
 
             for (const key in fixt_properties) {
                 expect(e[key]).toBe(fixt_properties[key]);
@@ -55,20 +47,17 @@ describe('Reon', () => {
             }
         });
 
-        Reon.forward(handler, fixt_target, fixt_event, fixt_properties);
+        Reon.forward(handler, fixt_event, fixt_properties);
 
         expect(handler.mock.calls.length).toBe(1);
     });
 
     it('should be able to forward React events', () => {
-        const fixt_target = Symbol('target');
         const fixt_properties = { foo: 'bar' };
 
         const handler = jest.fn(e => {
             expect(e instanceof Reon).toBe(true);
             expect(isSyntheticEvent(e.reactEvent)).toBe(true);
-
-            expect(e.target).toBe(fixt_target);
 
             expect(e.isDefaultPrevented()).toBeFalsy();
             expect(e.isPropagationStopped()).toBeFalsy();
@@ -87,7 +76,7 @@ describe('Reon', () => {
         });
 
         const button = TestUtils.renderIntoDocument(
-            <button onClick={e => Reon.forward(handler, fixt_target, e, fixt_properties)} />
+            <button onClick={e => Reon.forward(handler, e, fixt_properties)} />
         );
         fireEvent.click(button);
 
@@ -95,7 +84,6 @@ describe('Reon', () => {
     });
 
     it('should be able to forward native events', () => {
-        const fixt_target = Symbol('target');
         const fixt_properties = { foo: 'bar' };
 
         const fixt_event = new Event('click');
@@ -105,8 +93,6 @@ describe('Reon', () => {
             expect(e instanceof Reon).toBe(true);
             expect(e.reactEvent).toBeUndefined();
             expect(e.nativeEvent instanceof Event).toBe(true);
-
-            expect(e.target).toBe(fixt_target);
 
             expect(e.isDefaultPrevented()).toBeFalsy();
             expect(e.isPropagationStopped()).toBeFalsy();
@@ -123,20 +109,20 @@ describe('Reon', () => {
             }
         });
 
-        Reon.forward(handler, fixt_target, fixt_event, fixt_properties);
+        Reon.forward(handler, fixt_event, fixt_properties);
         expect(handler.mock.calls.length).toBe(1);
     });
 
     it('should throw when triggering with a synthetic event', () => {
-        const fixt_event = new Reon(undefined, {});
+        const fixt_event = new Reon({});
 
-        const test = () => Reon.trigger(undefined, undefined, { e: fixt_event });
+        const test = () => Reon.trigger(undefined, { e: fixt_event });
         expect(test).toThrow();
     });
 
     it('should throw when forwarding with a non-event', () => {
         console.error = jest.fn();
-        Reon.forward(undefined, undefined, undefined, {});
+        Reon.forward(undefined, undefined, {});
         expect(console.error).toBeCalled();
     });
 
@@ -149,7 +135,7 @@ describe('Reon', () => {
 
         expect(result.isDefaultPrevented()).toBeTruthy();
         expect(result.isPropagationStopped()).toBeTruthy();
-    })
+    });
 
     it('should return defaultPrevented/stopPropagation state after forward', () => {
         const handler = e => {
@@ -161,7 +147,7 @@ describe('Reon', () => {
 
         expect(result.isDefaultPrevented()).toBeTruthy();
         expect(result.isPropagationStopped()).toBeTruthy();
-    })
+    });
 
     it('should preserve original property descriptors', () => {
         const eventData = Object.defineProperty({}, 'propTest', {
@@ -193,6 +179,89 @@ describe('Reon', () => {
 
         Reon.trigger(handler, undefined, eventData);
         expect(handler.mock.calls.length).toBe(1);
-    })
+    });
 
+
+    describe('@deprecated', () => {
+
+        const fixt_target = createElement('div');
+        const fixt_properties = { foo: 'bar' };
+
+        let consoleError;
+
+        beforeAll(() => {
+            consoleError = console.error;
+            console.error = (msg, ...args) => {
+                if (msg.indexOf('Deprecated:') === 0)
+                    return;
+
+                consoleError(msg, ...args);
+            };
+        });
+
+        afterAll(() => {
+            console.error = consoleError;
+        });
+
+        function createHandler(target, properties) {
+            return jest.fn(e => {
+                expect(e instanceof Reon).toBe(true);
+                expect(e.target).toBe(target);
+
+                if (properties) {
+                    for (const key in properties) {
+                        expect(e[key]).toBe(properties[key]);
+                    }
+                }
+            });
+        }
+
+        it('should work with signature Reon.trigger(handler, element, properties)', () => {
+            const handler = createHandler(fixt_target, fixt_properties);
+            Reon.trigger(handler, fixt_target, fixt_properties);
+            expect(handler.mock.calls.length).toBe(1);
+        });
+
+        it('should work with signature Reon.trigger(handler, element)', () => {
+            const handler = createHandler(fixt_target);
+            Reon.trigger(handler, fixt_target);
+            expect(handler.mock.calls.length).toBe(1);
+        });
+
+        it('should work with signature Reon.trigger(handler, [falsy], properties)', () => {
+            const handler = createHandler(undefined);
+            Reon.trigger(handler, null, fixt_properties);
+            expect(handler.mock.calls.length).toBe(1);
+        });
+
+        it('should work with signature Reon.forward(handler, element, evt, properties)', () => {
+            const handler = createHandler(fixt_target, fixt_properties);
+            const evt = new Reon();
+
+            Reon.forward(handler, fixt_target, evt, fixt_properties);
+            expect(handler.mock.calls.length).toBe(1);
+        });
+
+        it('should work with signature Reon.forward(handler, element, evt)', () => {
+            const handler = createHandler(fixt_target);
+            const evt = new Reon();
+
+            Reon.forward(handler, fixt_target, evt);
+            expect(handler.mock.calls.length).toBe(1);
+        });
+
+        it('should work with signature Reon.forward(handler, [falsy], evt, properties)', () => {
+            const handler = createHandler(undefined);
+            const evt = new Reon();
+
+            Reon.forward(handler, null, evt, fixt_properties);
+            expect(handler.mock.calls.length).toBe(1);
+        });
+
+        it('should be able to create ReonEvent instances with deprecated arguments', () => {
+            const e = new Reon(fixt_target);
+            expect(e.target).toBe(fixt_target);
+        });
+
+    });
 });


### PR DESCRIPTION
The second argument for trigger and forward has always been expected to point to the react element causing the event. It was then provided as e.target to the event handler. This behaviour encourages exposing the inner interface of a component which isn't desirable as well as makes it awkward to use Reon with functional components.

@JorgenEvens not sure if adding React as peerDependency again should be considered a breaking change. Modern NPM doesn't care but older npm would break on this so yeah.